### PR TITLE
Small "typo" in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The YAJL framework is an Objective-C framework for the [YAJL](http://lloyd.githu
 - In `Build Settings`:
   - Under `Framework Search Paths` make sure the (parent) directory to `YAJLiOS.framework` is listed.
   - Under `Other Linker Flags` in your target, add `-ObjC` and `-all_load`
-- Import with `#import <YAJL/YAJL.h>`.
+- Import with `#import <YAJLiOS/YAJL.h>`.
 - See the [API documenation](http://gabriel.github.com/yajl-objc/)
 
 ## Installing in XCode 3 (iOS)


### PR DESCRIPTION
There was a small typo in the docs. For iOS the proper framework path is `<YAJLiOS/YAJL.h>`.
