### PR TITLE
Notify the end of document while parsing with YAJLDocument

### DIFF
--- a/Classes/YAJLDocument.h
+++ b/Classes/YAJLDocument.h
@@ -75,6 +75,12 @@ extern NSInteger YAJLDocumentStackCapacity;
  @param dict Dictionary object was set for key on
  */
 - (void)document:(YAJLDocument *)document didSetObject:(id)object forKey:(id)key inDictionary:(NSDictionary *)dict;
+
+/*!
+ Did reach the end of document.
+ @param document Sender
+ */
+- (void)didEndDocument:(YAJLDocument *)document;
 @end
 
 /*!

--- a/Classes/YAJLDocument.m
+++ b/Classes/YAJLDocument.m
@@ -172,6 +172,10 @@ NSInteger YAJLDocumentStackCapacity = 20;
     dict_ = (NSMutableDictionary *)value;
     currentType_ = YAJLDecoderCurrentTypeDict;
   }
+  if ([stack_ count] == 0) {
+    if ([delegate_ respondsToSelector:@selector(didEndDocument:)])
+      [delegate_ didEndDocument:self];
+  }
 }
 
 @end


### PR DESCRIPTION
While parsing a stream of JSON document, sometimes we need to know the end of document. 

Here, I'm using the stack count to determine this. Let me know if this is a good solution.
