### PR TITLE
add property on YAJLParser to get the number of bytes consumed after parsing

### DIFF
--- a/Classes/YAJLParser.h
+++ b/Classes/YAJLParser.h
@@ -152,6 +152,7 @@ typedef NSUInteger YAJLParserStatus; //!< Status of the last parse event
 @property (assign, nonatomic) id <YAJLParserDelegate> delegate;
 @property (readonly, retain, nonatomic) NSError *parserError;
 @property (readonly, nonatomic) YAJLParserOptions parserOptions;
+@property (readonly, nonatomic) unsigned int bytesConsumed;
 
 /*!
  Create parser with data and options.

--- a/Classes/YAJLParser.m
+++ b/Classes/YAJLParser.m
@@ -245,6 +245,10 @@ yajl_end_array
 
 //! @endinternal
 
+- (unsigned int)bytesConsumed {
+    return handle_ ? yajl_get_bytes_consumed(handle_) : 0;
+}
+
 - (YAJLParserStatus)parse:(NSData *)data {
   if (!handle_) {
     yajl_parser_config cfg = {


### PR DESCRIPTION
I'm using yajl-objc to parse a stream of JSON objects that are fed to my app without any delimiters, e.g.

``` javascript
{ "a":1 }{ "b": 2 }{"c":3} //...
```

The stream may stop in mid-object, as well:

``` javascript
{ "a":1 }{ "b": 
```

When I call `[YAJLParser parse:data]` with my (possibly partial) JSON, the parser correctly returns the first dictionary in the `data` object and stops.  At this point, I need the number of bytes consumed by the parser so I can construct a new NSData object that starts where the parser left off in the previous object.  This pull request simply exposes `yajl_get_bytes_consumed()` as a property on `YAJLParser` so I can do this.

Example code that shows this in action:

``` objective-c
// @property (nonatomic, strong) YAJLParser * parser;
// "buf" and "len" come from reading an NSInputStream

NSData * data = [NSData dataWithBytes:buf length:len];

// iterate over JSON object in the NSData object
unsigned int start = 0;
YAJLParserStatus status = YAJLParserStatusNone;
do {
    NSData * subdata = [data subdataWithRange:NSMakeRange(start, len-start)];

    // you can't reset a parser, so a new one needs to be created each time
    // parsing completes successfully.
    if (!self.parser) {
        self.parser = [[YAJLParser alloc] initWithParserOptions:YAJLParserOptionsAllowComments];
        self.parser.delegate = self;
    }

    status = [self.parser parse:subdata];
    start += self.parser.bytesConsumed; // new addition!

    if (status = YAJLParserStatusOK) {
        self.parser = nil;
    }
} while (status == YAJLParserStatusOK && start < len);
```
