### PR TITLE
Support using enums from Obj-C++

### DIFF
--- a/Classes/NS_ENUM.h
+++ b/Classes/NS_ENUM.h
@@ -1,0 +1,3 @@
+#ifndef NS_ENUM
+#define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+#endif

--- a/Classes/YAJLGen.h
+++ b/Classes/YAJLGen.h
@@ -28,18 +28,18 @@
 //
 
 #include "yajl_gen.h"
+#include "NS_ENUM.h"
 
 
 extern NSString *const YAJLGenInvalidObjectException; //! Exception type if we encounter invalid object
 
 //! JSON generate options
-enum YAJLGenOptions {
+typedef NS_ENUM(NSUInteger, YAJLGenOptions) {
   YAJLGenOptionsNone = 0, //!< No options
   YAJLGenOptionsBeautify = 1 << 0, //!< Beautifiy JSON output
   YAJLGenOptionsIgnoreUnknownTypes = 1 << 1, //!< Ignore unknown types (will use null value)
   YAJLGenOptionsIncludeUnsupportedTypes = 1 << 2, //!< Handle non-JSON types (including NSDate, NSData, NSURL)
 };
-typedef NSUInteger YAJLGenOptions;
 
 /*!
  YAJL JSON string generator.

--- a/Classes/YAJLParser.h
+++ b/Classes/YAJLParser.h
@@ -29,6 +29,7 @@
 
 
 #include "yajl_parse.h"
+#include "NS_ENUM.h"
 
 
 extern NSString *const YAJLErrorDomain; //! Error domain for YAJL
@@ -38,30 +39,27 @@ extern NSString *const YAJLParsingUnsupportedException; //! Parsing unsupported 
 extern NSString *const YAJLParserValueKey; //! Key in NSError userInfo for value we errored on
 
 //! Parser error codes
-enum YAJLParserErrorCode {
+typedef NS_ENUM(NSInteger, YAJLParserErrorCode) {
   YAJLParserErrorCodeAllocError = -1000, //!< Alloc error
   YAJLParserErrorCodeDoubleOverflow = -1001, //!< Double overflow
   YAJLParserErrorCodeIntegerOverflow = -1002 //!< Integer overflow
 };
-typedef NSInteger YAJLParserErrorCode; //! Parser error codes
 
 //! Parser options
-enum YAJLParserOptions {
+typedef NS_ENUM(NSUInteger, YAJLParserOptions) {
   YAJLParserOptionsNone = 0, //!< No options
   YAJLParserOptionsAllowComments = 1 << 0, //!< Javascript style comments will be allowed in the input (both /&asterisk; &asterisk;/ and //)
   YAJLParserOptionsCheckUTF8 = 1 << 1, //!< Invalid UTF8 strings will cause a parse error
   YAJLParserOptionsStrictPrecision = 1 << 2, //!< If YES will force strict precision and return integer overflow error
 };
-typedef NSUInteger YAJLParserOptions; //! Parser options
 
 //! Parser status
-enum {
+typedef NS_ENUM(NSUInteger, YAJLParserStatus) {
   YAJLParserStatusNone = 0,  //!< No status
-  YAJLParserStatusOK = 1, //!< Parsed OK 
+  YAJLParserStatusOK = 1, //!< Parsed OK
   YAJLParserStatusInsufficientData = 2, //!< There was insufficient data
   YAJLParserStatusError = 3 //!< Parser errored
 };
-typedef NSUInteger YAJLParserStatus; //!< Status of the last parse event
 
 
 @class YAJLParser;

--- a/Project-iOS/YAJLiOS.xcodeproj/project.pbxproj
+++ b/Project-iOS/YAJLiOS.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 		00C406470FE77C51003CE908 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.md; path = ../README.md; sourceTree = SOURCE_ROOT; };
 		AA747D9E0F9514B9006C5449 /* YAJLiOS_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YAJLiOS_Prefix.pch; sourceTree = SOURCE_ROOT; };
 		AACBBE490F95108600F1A2B1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		AE50688F1A93EB5100FBEA93 /* NS_ENUM.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NS_ENUM.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -385,6 +386,7 @@
 				00C405010FE77661003CE908 /* YAJLParser.m */,
 				00C113F412111824009C9B51 /* NSBundle+YAJL.h */,
 				00C113F512111824009C9B51 /* NSBundle+YAJL.m */,
+				AE50688F1A93EB5100FBEA93 /* NS_ENUM.h */,
 			);
 			name = Classes;
 			path = ../Classes;

--- a/yajl-objc.podspec
+++ b/yajl-objc.podspec
@@ -8,4 +8,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/a2/yajl-objc.git", :branch => "master" }
   s.source_files = 'Classes/*.{h,m}', 'Libraries/{GHKit,GTM}/*.{h,m}'
   s.dependency     'yajl', '~>1.0.11'
+  s.requires_arc = false
 end


### PR DESCRIPTION
When importing YAJL-objc headers into ObjC++ files, the enum integer re-declarations fail (because they're not allowed). This pull request changes to use NS_ENUM.

We also added `requires_arc = false` to the Podspec, since it appears all the files use MRC.